### PR TITLE
Доработка ClickHouseDataService для работы с WOLV

### DIFF
--- a/NewPlatform.Flexberry.ORM.ClickHouseDataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ClickHouseDataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ClickHouseDataService</id>
-    <version>1.0.0-alpha03</version>
+    <version>1.0.0-alpha04</version>
     <title>Flexberry ORM ClickHouseDataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>

--- a/NewPlatform.Flexberry.ORM.ClickHouseDataService/ClickHouseDataService.cs
+++ b/NewPlatform.Flexberry.ORM.ClickHouseDataService/ClickHouseDataService.cs
@@ -623,5 +623,26 @@
                 }
             }
         }
+
+        public override void GenerateSQLRowNumber(LoadingCustomizationStruct customizationStruct, ref string resQuery, string orderByExpr)
+        {
+            string nl = Environment.NewLine;
+            if (customizationStruct.RowNumber != null)
+            {
+                int fromInd = resQuery.IndexOf("FROM (");
+                string селектСамогоВерхнегоУр = resQuery.Substring(0, fromInd);
+
+                if (!string.IsNullOrEmpty(orderByExpr))
+                {
+                    resQuery = resQuery.Replace(orderByExpr, string.Empty);
+                }
+                    resQuery = resQuery.Insert(fromInd, "," + nl + "rowNumberInAllBlocks() as \"RowNumber\"" + nl);
+
+                int startRow = customizationStruct.RowNumber.StartRow - 1;
+                int endRow = customizationStruct.RowNumber.EndRow - 1;
+                resQuery = селектСамогоВерхнегоУр + nl + "FROM (" + nl + resQuery + ") rn" + nl + "where \"RowNumber\" between " + startRow.ToString() + " and " + endRow.ToString() + nl +
+                    orderByExpr;
+            }
+        }
     }
 }

--- a/NewPlatform.Flexberry.ORM.ClickHouseDataService/ClickHouseDataService.cs
+++ b/NewPlatform.Flexberry.ORM.ClickHouseDataService/ClickHouseDataService.cs
@@ -100,7 +100,7 @@
 
             if (valType == typeof(DateTime))
             {
-                return "'" + ((DateTime)value).ToString(System.Globalization.DateTimeFormatInfo.InvariantInfo) + "." + ((DateTime)value).ToString("fff") + "'";
+                return "'" + ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss") + "'";
             }
 
             if (valType == typeof(TimeSpan))


### PR DESCRIPTION
Поменяли формат даты при генерации запроса
Изменилы формат даты в запросе на yyyy-mm-dd hh:MM:ss

Переопределили GenerateSQLRowNumber
В ClickHouse функция нумерации строк rowNumberInAllBlocks(), в связи с чем был переопределён метод генерации запроса